### PR TITLE
Add desktop collapsed menu icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,12 +260,13 @@
     }
     .nav-links {
       padding: 0 20px;
-      display: flex;
+      display: none;
       flex-wrap: wrap;
       justify-content: center;
       align-items: center;
     }
     .nav-links.show {
+      display: flex;
       position: absolute;
       top: 100%;
       left: 0;


### PR DESCRIPTION
## Summary
- hide navigation links by default
- display nav menu when the menu icon is clicked on desktop or mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643b29eb4483219b436878452118f0