### PR TITLE
Add persistent hamburger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
       justify-content: space-between;
       align-items: center;
       padding: 10px 20px;
+      position: relative;
     }
 
     .nav-logo img {
@@ -48,8 +49,14 @@
     }
 
     .nav-links {
-      display: flex;
-      gap: 20px;
+      display: none;
+      flex-direction: column;
+      position: absolute;
+      top: 100%;
+      right: 20px;
+      background-color: white;
+      padding: 15px 20px;
+      border: 1px solid #ddd;
     }
 
     .nav-links a {
@@ -58,10 +65,15 @@
       font-size: 0.9em;
       text-transform: uppercase;
       letter-spacing: 1px;
+      margin: 10px 0;
+    }
+
+    .nav-links.show {
+      display: flex;
     }
 
     .nav-toggle {
-      display: none;
+      display: flex;
       flex-direction: column;
       justify-content: space-between;
       width: 24px;
@@ -201,19 +213,10 @@
       }
 
       .nav-links {
-        display: none;
-        flex-direction: column;
         width: 100%;
-        background-color: white;
-        padding: 15px 0;
-        position: absolute;
-        top: 100%;
         left: 0;
+        flex-direction: column;
         border-top: 1px solid #ddd;
-      }
-
-      .nav-links.show {
-        display: flex;
       }
 
       .nav-container {


### PR DESCRIPTION
## Summary
- keep nav menu collapsed by default on all screen sizes
- show a hamburger icon and dropdown menu on desktop and mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68655c43f8e08321958095cefed97fd1