### PR TITLE
Display nav toggle on desktop and mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     }
 
     .nav-toggle {
-      display: none;
+      display: flex;
       flex-direction: column;
       justify-content: space-between;
       width: 24px;
@@ -209,7 +209,6 @@
       }
 
         .nav-toggle {
-          display: flex;
           order: 2;
         }
 


### PR DESCRIPTION
## Summary
- make the hamburger button visible by default
- remove the display override in the mobile media query

## Testing
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865689e762483219801a6ee940c0cb4