### PR TITLE
Fix mobile hamburger visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,12 +66,13 @@
     }
 
     .nav-toggle {
-      display: flex;
+      display: none;
       flex-direction: column;
       justify-content: space-between;
       width: 24px;
       height: 18px;
       cursor: pointer;
+      margin-left: auto;
     }
 
     .nav-toggle span {
@@ -204,6 +205,10 @@
         .nav-toggle {
           display: flex;
           order: 2;
+          position: absolute;
+          top: 50%;
+          right: 20px;
+          transform: translateY(-50%);
         }
 
       .nav-links {


### PR DESCRIPTION
## Summary
- hide hamburger icon on desktop
- show hamburger button fixed to the top-right on small screens

## Testing
- `html5validator --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656cc1c7548321b5db78fbe0fbc93f