### PR TITLE
Show larger hamburger icon on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,16 +69,17 @@
       display: none;
       flex-direction: column;
       justify-content: space-between;
-      width: 24px;
-      height: 18px;
+      width: 30px;
+      height: 24px;
       cursor: pointer;
       margin-left: auto;
+      z-index: 1101;
     }
 
     .nav-toggle span {
       display: block;
       width: 100%;
-      height: 2px;
+      height: 3px;
       background: #111;
     }
     header {


### PR DESCRIPTION
## Summary
- enlarge the mobile menu button
- bump its z-index to ensure it's visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68656e2a7b84832187007b66580f3e25